### PR TITLE
[Fix] 초기 연동 페이지에서 닉네임 설정했는데 제대로 조회되지 않는 문제 발생

### DIFF
--- a/src/api/initialSetup/initialSetup1.js
+++ b/src/api/initialSetup/initialSetup1.js
@@ -2,10 +2,8 @@ import { request } from '@/api/index.js';
 
 export const saveNickname = async (nickname) => {
   try {
-    // 백엔드 컨트롤러가 PATCH 요청을 기대하므로 PATCH 사용
-    // UpdateNicknameRequestDTO 형식에 맞춰 데이터 전송
     const response = await request.patch('/cheongsan/user/profile/name', {
-      nickname: nickname, // UpdateNicknameRequestDTO의 nickname 필드
+      nickname: nickname,
     });
     return response;
   } catch (error) {

--- a/src/assets/styles/pages/InitialSetup/InitialSetup2.module.css
+++ b/src/assets/styles/pages/InitialSetup/InitialSetup2.module.css
@@ -16,6 +16,9 @@
   color: navy;
   line-height: 2.3rem;
 }
+.nickname {
+  font-weight: bold;
+}
 .title-box p {
   margin-top: 2rem;
   font-size: 16px;

--- a/src/pages/InitialSetup/InitialSetup1.vue
+++ b/src/pages/InitialSetup/InitialSetup1.vue
@@ -4,9 +4,11 @@ import ProgressHeader from '@/components/domain/InitialSetup/ProgressHeader.vue'
 import { ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { saveNickname } from '@/api/initialSetup/initialSetup1.js';
+import { useAuthStore } from '@/stores/auth.js';
 
 const nickname = ref('');
 const router = useRouter();
+const authStore = useAuthStore();
 
 const nicknameRegex = /^[가-힣a-zA-Z0-9_]{2,10}$/;
 
@@ -22,6 +24,9 @@ const goNext = async () => {
 
   try {
     const response = await saveNickname(nicknameValue);
+
+    authStore.state.user.nickName = nicknameValue;
+    localStorage.setItem('auth', JSON.stringify(authStore.state));
 
     alert(response.message || '닉네임이 저장되었습니다.');
 
@@ -64,7 +69,9 @@ const goNext = async () => {
           maxlength="10"
           placeholder="닉네임을 입력하세요."
         />
-        <p :class="styles.initialSetup1TextLimit">(최대 10자)</p>
+        <p :class="styles.initialSetup1TextLimit">
+          (한글, 영문, 숫자, 밑줄(_) 포함 2~10자)
+        </p>
       </div>
       <button :class="styles.initialSetup1NextButton" @click="goNext">
         다음

--- a/src/pages/InitialSetup/InitialSetup2.vue
+++ b/src/pages/InitialSetup/InitialSetup2.vue
@@ -1,12 +1,16 @@
 <script setup>
-import { onMounted } from 'vue';
+import { onMounted, computed } from 'vue';
 import { useRouter } from 'vue-router';
 
 import animation from '@/assets/styles/pages/InitialSetup/InitialSetup2.module.scss';
 import styles from '@/assets/styles/pages/InitialSetup/InitialSetup2.module.css';
 import ProgressHeader from '@/components/domain/InitialSetup/ProgressHeader.vue';
+import { useAuthStore } from '@/stores/auth.js';
 
 const router = useRouter();
+const authStore = useAuthStore();
+
+const nickname = computed(() => authStore.getUser().nickName || '000'); // 없으면 fallback
 
 onMounted(() => {
   setTimeout(() => {
@@ -22,7 +26,8 @@ onMounted(() => {
       <div :class="styles.titleBox">
         <h2>마이데이터<br />연동 중</h2>
         <p>
-          000님의 자산내역을 불러오는 중입니다. <br />
+          <span :class="styles.nickname">{{ nickname }}</span
+          >님의 자산내역을 불러오는 중입니다. <br />
           잠시만 기다려주세요.
         </p>
         <img src="/images/logo-blue.png" alt="로고" />

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -1,64 +1,67 @@
 <script setup>
-import { useAuthStore } from "@/stores/auth";
-import { ref } from "vue";
-import { useRoute, useRouter } from "vue-router";
-import NaverAuthButton from "@/components/domain/Signup/NaverAuthButton.vue";
-import styles from "@/assets/styles/pages/Login.module.css";
+import { useAuthStore } from '@/stores/auth';
+import { ref } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import NaverAuthButton from '@/components/domain/Signup/NaverAuthButton.vue';
+import styles from '@/assets/styles/pages/Login.module.css';
 
 const router = useRouter();
 const route = useRoute();
 const authStore = useAuthStore();
 
 // 폼 데이터
-const formData = ref({ username: "", password: "" });
+const formData = ref({ username: '', password: '' });
 
 // 에러 상태
-const errorMessage = ref("");
+const errorMessage = ref('');
 const isSubmitting = ref(false);
 
 // URL 파라미터에서 에러 메시지 확인
-if (route.query.error === "session_expired") {
-  errorMessage.value = "세션이 만료되었습니다. 다시 로그인해주세요.";
-} else if (route.query.error === "login_required") {
-  errorMessage.value = "로그인이 필요한 서비스입니다.";
+if (route.query.error === 'session_expired') {
+  errorMessage.value = '세션이 만료되었습니다. 다시 로그인해주세요.';
+} else if (route.query.error === 'login_required') {
+  errorMessage.value = '로그인이 필요한 서비스입니다.';
 }
 
 // 일반 로그인 처리
 const handleLogin = async () => {
   // 유효성 검사
   if (!formData.value.username.trim()) {
-    errorMessage.value = "아이디를 입력해주세요.";
+    errorMessage.value = '아이디를 입력해주세요.';
     return;
   }
   if (!formData.value.password.trim()) {
-    errorMessage.value = "비밀번호를 입력해주세요.";
+    errorMessage.value = '비밀번호를 입력해주세요.';
     return;
   }
 
   isSubmitting.value = true;
-  errorMessage.value = "";
+  errorMessage.value = '';
 
   try {
     const result = await authStore.login(formData.value);
 
-    const rawRole = result?.role ?? authStore.state.user?.role ?? "";
-    const isAdmin = String(rawRole).toUpperCase().includes("ADMIN");
+    const rawRole = result?.role ?? authStore.state.user?.role ?? '';
+    const isAdmin = String(rawRole).toUpperCase().includes('ADMIN');
 
     const nick = (
       result?.nickName ??
       authStore.state.user?.nickName ??
-      ""
+      ''
     ).trim();
 
     if (isAdmin) {
-      router.push("/admin/users");
-    } else if (!nick) {
-      router.push("/initialSetup/page1");
+      router.push('/admin/users');
     } else {
-      router.push("/home");
+      router.push('/initialSetup/page1');
     }
+    // else if (!nick) {
+    //   router.push("/initialSetup/page1");
+    // } else {
+    //   router.push("/home");
+    // }
   } catch (error) {
-    errorMessage.value = error?.message ?? "로그인에 실패했습니다.";
+    errorMessage.value = error?.message ?? '로그인에 실패했습니다.';
   } finally {
     isSubmitting.value = false;
   }
@@ -66,7 +69,7 @@ const handleLogin = async () => {
 
 // 네이버 인증 이벤트 핸들러
 const handleNaverAuthStart = () => {
-  errorMessage.value = "";
+  errorMessage.value = '';
 };
 const handleNaverAuthSuccess = () => {};
 const handleNaverAuthError = (error) => {
@@ -116,7 +119,7 @@ const handleNaverAuthError = (error) => {
           :class="[styles.loginButton, { [styles.loading]: isSubmitting }]"
           :disabled="isSubmitting"
         >
-          {{ isSubmitting ? "로그인 중..." : "Login" }}
+          {{ isSubmitting ? '로그인 중...' : 'Login' }}
         </button>
       </form>
 

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -52,14 +52,11 @@ const handleLogin = async () => {
 
     if (isAdmin) {
       router.push('/admin/users');
-    } else {
+    } else if (!nick) {
       router.push('/initialSetup/page1');
+    } else {
+      router.push('/home');
     }
-    // else if (!nick) {
-    //   router.push("/initialSetup/page1");
-    // } else {
-    //   router.push("/home");
-    // }
   } catch (error) {
     errorMessage.value = error?.message ?? '로그인에 실패했습니다.';
   } finally {


### PR DESCRIPTION
## #️⃣ Issue Number

닉네임 설정 및 조회 오류 해결

## 📝 요약(Summary)
닉네임 설정 시,
api 연동으로 인해 db에 저장은 정상적으로 되지만,
authStore와 연결하지 않아서 해당 내용이 프론트에 미적용되었음.

따라서, authStore에 닉네임 값을 저장하여 프론트에서 닉네임을 정상적으로 조회할 수 있도록 수정함.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
